### PR TITLE
Fix Incorrect identifier in build.gradle.kts

### DIFF
--- a/templates/1.20.1/{{ fabric_path }}/build.gradle.kts.jinja
+++ b/templates/1.20.1/{{ fabric_path }}/build.gradle.kts.jinja
@@ -6,7 +6,7 @@ architectury {
     fabric()
 }
 
-{{ modid }}ModDependencies {
+{{ classname|lower }}ModDependencies {
     // expand versions in fabric.mod.json
     filesMatching.add("fabric.mod.json")
 

--- a/templates/1.20.1/{{ forge_path }}/build.gradle.kts.jinja
+++ b/templates/1.20.1/{{ forge_path }}/build.gradle.kts.jinja
@@ -32,7 +32,7 @@ loom {
     }
 }
 
-{{ modid }}ModDependencies {
+{{ classname|lower }}ModDependencies {
     // expand versions in mods.toml
     filesMatching.add("META-INF/mods.toml")
 


### PR DESCRIPTION
replaces `{{ modid }}ModDependencies`
with  `{{ classname|lower }}ModDependencies`
to match
```
val extension = extensions.create<{{ classname }}ModDependenciesExtension>("{{ classname|lower }}ModDependencies")
```

note: I did not test this as I have no clue how to